### PR TITLE
feat: use GKE3 endpoint, hmac and all

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,18 @@ npm install greenkeeper-postpublish --save-dev
 Then add it to your `scripts` in your `package.json`:
 ```json
   "scripts": {
-    "postpublish": "greenkeeper-postpublish"
+    "postpublish": "greenkeeper-postpublish --secret=$GK_NPMHOOK_SECRET --installation=$GK_INSTALLATION_ID"
   }
 ```
+
+You can also set the `secret` and `installation` values in your publish environment:
+
+```
+gk_secret=$GK_NPMHOOK_SECRET
+gh_installation=$GK_INSTALLATION_ID
+```
+
+Where the `GK_NPMHOOK_SECRET` is set in your Greenkeeper Enterprise Admin Dashboard at https://gke.your-company.com:8800 and `GK_INSTALLATION_ID` can be found in your GitHub Enterprise setup on the organisation for your modules: https://ghe.your-company.com/organizations/$organisation_name/settings/installations -> Greenkeeper -> the integer number in the URL.
 
 When set up like this, every time your release the package (with `npm publish`),
 it will let Greenkeeper know that there is a new version available.
@@ -33,7 +42,7 @@ parse it and use its `name` and `version`.
 You can also specify the `--pkgname` and `--pkgversion` parameters instead:
 
 ```
-greenkeeper-postpublish --pkgname mypackage --pkgversion 4.2.0
+greenkeeper-postpublish --pkgname mypackage --pkgversion 4.2.0 --secret=abcd --installation=54321
 ```
 
 🌴


### PR DESCRIPTION
BREAKING CHANGE:

This will no longer work with Greenkeeper Enterprise < 3.

Usage:

greenkeeper-postpublish \
  [--pkgname=foo \]
  [--pkgversion=1.2.3 \]
  --api=https://gke.your-company.com/hooks
  --secret=NPMHOOKS_SECRET
  --installation=$GH_INSTALLATION_ID